### PR TITLE
Fix typo in no assets module configured exception message

### DIFF
--- a/lib/scenic/assets/static.ex
+++ b/lib/scenic/assets/static.ex
@@ -22,7 +22,7 @@ defmodule Scenic.Assets.Static do
   * __Assets Directory__: Typically `/assets` in your main app source directory. This is the
     folder that holds your raw asset files.
   * __Assets Module__: A module in your application that builds and holds the asset library.
-  * __Assets Config__: Configuration scripts in your application that indicates where the 
+  * __Assets Config__: Configuration scripts in your application that indicates where the
     assets directory is and your assets module.
 
   #### Assets Directory
@@ -98,7 +98,7 @@ defmodule Scenic.Assets.Static do
 
 
   IMPORTANT NOTE: When you add a new asset to the assets directory, you may need to force this
-  module to recompile for them to be usable. Adding or removing a return at the end should do 
+  module to recompile for them to be usable. Adding or removing a return at the end should do
   the trick. In the future, there will be a file system watcher (much like Phoenix has) that
   will do this automatically. Until then, it is pretty easy to do manually.
 
@@ -306,7 +306,7 @@ defmodule Scenic.Assets.Static do
       _ ->
         raise """
         No assets module is configured.
-        You need to create an assets modulein your application.
+        You need to create an assets module in your application.
         Then connect it to Scenic with some config.
 
         Example assets module that includes an optional alias:


### PR DESCRIPTION
## Description
While following the upgrade guide, we noticed a small typo in one of the exception messages.

## Motivation and Context
Makes it easier to read the error message.

## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
