### PR TITLE
Allow assign to take a map

### DIFF
--- a/lib/scenic/scene.ex
+++ b/lib/scenic/scene.ex
@@ -391,11 +391,15 @@ defmodule Scenic.Scene do
   end
 
   @doc """
-  Convenience function to assign a list of values into a scene struct.
+  Convenience function to assign a list or map of values into a scene struct.
   """
-  @spec assign(scene :: Scene.t(), key_list :: Keyword.t()) :: Scene.t()
-  def assign(%Scene{} = scene, key_list) when is_list(key_list) do
-    Enum.reduce(key_list, scene, fn {k, v}, acc -> assign(acc, k, v) end)
+  @spec assign(scene :: Scene.t(), assigns :: Keyword.t() | map()) :: Scene.t()
+  def assign(%Scene{} = scene, assigns) when is_list(assigns) do
+    Enum.reduce(assigns, scene, fn {k, v}, acc -> assign(acc, k, v) end)
+  end
+
+  def assign(%Scene{} = scene, assigns) when is_map(assigns) do
+    %Scene{scene | assigns: Map.merge(scene.assigns, assigns)}
   end
 
   @doc """

--- a/test/scenic/scene_test.exs
+++ b/test/scenic/scene_test.exs
@@ -195,6 +195,19 @@ defmodule Scenic.SceneTest do
     assert scene.assigns == %{one: 1, two: 2, three: "three"}
   end
 
+  test "assign assigns multiple values in a map", %{scene: scene} do
+    assert scene.assigns == %{}
+
+    scene =
+      Scene.assign(scene, %{
+        one: 1,
+        two: 2,
+        three: "three"
+      })
+
+    assert scene.assigns == %{one: 1, two: 2, three: "three"}
+  end
+
   test "get gets a value from assigns - works like map", %{scene: scene} do
     scene =
       Scene.assign(scene,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description

This PR allows `assign` to take a map of values, like Phoenix does.

## Motivation and Context

When working on a Scenic project, we captured the entire `scene.assigns` and transformed a few values. We received an error when trying to assign this resulting map back to the scene, since `scene.assigns` gave us a map. We referenced Phoenix's behavior of `assigns` since that was motivation for bringing it into Scenic, and Phoenix does in fact allow both a keyword list or map as assigns. Therefore we thought we should allow for assigning a map in Scenic as well.

Happy to discuss if this either isn't desired or should be implemented differently.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
