### PR TITLE
Allows `assign_new/2` to take a map of values

### DIFF
--- a/lib/scenic/driver.ex
+++ b/lib/scenic/driver.ex
@@ -358,13 +358,17 @@ defmodule Scenic.Driver do
   end
 
   @doc """
-  Convenience function to assign a list of new values into a driver struct.
+  Convenience function to assign a list or map of new values into a driver struct.
 
   Only values that do not already exist will be assigned
   """
-  @spec assign_new(driver :: Driver.t(), key_list :: Keyword.t()) :: Driver.t()
+  @spec assign_new(driver :: Driver.t(), key_list :: Keyword.t() | map) :: Driver.t()
   def assign_new(%Driver{} = driver, key_list) when is_list(key_list) do
     Enum.reduce(key_list, driver, fn {k, v}, acc -> assign_new(acc, k, v) end)
+  end
+
+  def assign_new(%Driver{assigns: assigns} = driver, key_map) when is_map(key_map) do
+    %{driver | assigns: Map.merge(key_map, assigns)}
   end
 
   @doc """

--- a/test/scenic/driver_test.exs
+++ b/test/scenic/driver_test.exs
@@ -214,6 +214,24 @@ defmodule Scenic.DriverTest do
     assert Driver.fetch(driver, :def) == {:ok, 456}
   end
 
+  test "assign_new assigns map of values" do
+    driver =
+      %Driver{}
+      |> Driver.assign_new(%{abc: 123, def: 456})
+
+    assert Driver.fetch(driver, :abc) == {:ok, 123}
+    assert Driver.fetch(driver, :def) == {:ok, 456}
+  end
+
+  test "assign_new with a map ignores existing values" do
+    driver =
+      %Driver{assigns: %{abc: 123}}
+      |> Driver.assign_new(%{abc: 789, def: 456})
+
+    assert Driver.fetch(driver, :abc) == {:ok, 123}
+    assert Driver.fetch(driver, :def) == {:ok, 456}
+  end
+
   test "set_busy sets the busy flag" do
     driver = %Driver{}
     assert Map.get(driver, :busy) == false


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description

Thanks to @amclain and @thejohncotton for the inspiration.

This PR allows `assign_new` to take a map of values like `assign`.

<!--- Describe your changes in detail -->

## Motivation and Context

Consistency in the API is essential, in line with the recent work of `assign/2` taking a list or map. Building on the previous work allows `assign_new/2` to work with either a keyword list or map.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
