### PR TITLE
Allows `assign_new/2` to take a map of values

### DIFF
--- a/lib/scenic/driver.ex
+++ b/lib/scenic/driver.ex
@@ -344,9 +344,13 @@ defmodule Scenic.Driver do
   @doc """
   Convenience function to assign a list of values into a driver struct.
   """
-  @spec assign(driver :: Driver.t(), key_list :: Keyword.t()) :: Driver.t()
+  @spec assign(driver :: Driver.t(), key_list :: Keyword.t() | map) :: Driver.t()
   def assign(%Driver{} = driver, key_list) when is_list(key_list) do
     Enum.reduce(key_list, driver, fn {k, v}, acc -> assign(acc, k, v) end)
+  end
+
+  def assign(%Driver{assigns: assigns} = driver, key_map) when is_map(key_map) do
+    %{driver | assigns: Map.merge(assigns, key_map)}
   end
 
   @doc """
@@ -358,13 +362,17 @@ defmodule Scenic.Driver do
   end
 
   @doc """
-  Convenience function to assign a list of new values into a driver struct.
+  Convenience function to assign a list or map of new values into a driver struct.
 
   Only values that do not already exist will be assigned
   """
-  @spec assign_new(driver :: Driver.t(), key_list :: Keyword.t()) :: Driver.t()
+  @spec assign_new(driver :: Driver.t(), key_list :: Keyword.t() | map) :: Driver.t()
   def assign_new(%Driver{} = driver, key_list) when is_list(key_list) do
     Enum.reduce(key_list, driver, fn {k, v}, acc -> assign_new(acc, k, v) end)
+  end
+
+  def assign_new(%Driver{assigns: assigns} = driver, key_map) when is_map(key_map) do
+    %{driver | assigns: Map.merge(key_map, assigns)}
   end
 
   @doc """

--- a/lib/scenic/scene.ex
+++ b/lib/scenic/scene.ex
@@ -415,9 +415,13 @@ defmodule Scenic.Scene do
 
   Only values that do not already exist will be assigned
   """
-  @spec assign_new(scene :: Scene.t(), key_list :: Keyword.t()) :: Scene.t()
+  @spec assign_new(scene :: Scene.t(), key_list :: Keyword.t() | map) :: Scene.t()
   def assign_new(%Scene{} = scene, key_list) when is_list(key_list) do
     Enum.reduce(key_list, scene, fn {k, v}, acc -> assign_new(acc, k, v) end)
+  end
+
+  def assign_new(%Scene{assigns: assigns} = scene, key_map) when is_map(key_map) do
+    %{scene | assigns: Map.merge(key_map, assigns)}
   end
 
   @doc """

--- a/test/scenic/driver_test.exs
+++ b/test/scenic/driver_test.exs
@@ -188,6 +188,25 @@ defmodule Scenic.DriverTest do
     assert Driver.fetch(driver, :def) == {:ok, 456}
   end
 
+  test "assign assigns map of values" do
+    driver =
+      %Driver{}
+      |> Driver.assign(%{abc: 123, def: 456})
+
+    assert Driver.fetch(driver, :abc) == {:ok, 123}
+    assert Driver.fetch(driver, :def) == {:ok, 456}
+  end
+
+  test "assign_new overrides existing values" do
+    driver =
+      %Driver{assigns: %{abc: 123, hij: :original}}
+      |> Driver.assign(abc: 789, def: 456)
+
+    assert Driver.fetch(driver, :abc) == {:ok, 789}
+    assert Driver.fetch(driver, :def) == {:ok, 456}
+    assert Driver.fetch(driver, :hij) == {:ok, :original}
+  end
+
   test "assign_new assigns single value" do
     driver =
       %Driver{}
@@ -209,6 +228,24 @@ defmodule Scenic.DriverTest do
     driver =
       %Driver{assigns: %{abc: 123}}
       |> Driver.assign_new(abc: 789, def: 456)
+
+    assert Driver.fetch(driver, :abc) == {:ok, 123}
+    assert Driver.fetch(driver, :def) == {:ok, 456}
+  end
+
+  test "assign_new assigns map of values" do
+    driver =
+      %Driver{}
+      |> Driver.assign_new(%{abc: 123, def: 456})
+
+    assert Driver.fetch(driver, :abc) == {:ok, 123}
+    assert Driver.fetch(driver, :def) == {:ok, 456}
+  end
+
+  test "assign_new with a map ignores existing values" do
+    driver =
+      %Driver{assigns: %{abc: 123}}
+      |> Driver.assign_new(%{abc: 789, def: 456})
 
     assert Driver.fetch(driver, :abc) == {:ok, 123}
     assert Driver.fetch(driver, :def) == {:ok, 456}

--- a/test/scenic/scene_test.exs
+++ b/test/scenic/scene_test.exs
@@ -208,6 +208,36 @@ defmodule Scenic.SceneTest do
     assert scene.assigns == %{one: 1, two: 2, three: "three"}
   end
 
+  test "assign_new assigns list of values", %{scene: scene} do
+    scene = Scene.assign_new(scene, abc: 123, def: 456)
+
+    assert scene.assigns == %{abc: 123, def: 456}
+  end
+
+  test "assign_new ignores existing values", %{scene: scene} do
+    scene =
+      scene
+      |> Scene.assign(abc: :original)
+      |> Scene.assign_new(abc: 123, def: 456)
+
+    assert scene.assigns == %{abc: :original, def: 456}
+  end
+
+  test "assign_new assigns map of values", %{scene: scene} do
+    scene = Scene.assign_new(scene, %{abc: 123, def: 456})
+
+    assert scene.assigns == %{abc: 123, def: 456}
+  end
+
+  test "assign_new with a map ignores existing values", %{scene: scene} do
+    scene =
+      scene
+      |> Scene.assign(abc: :original)
+      |> Scene.assign_new(%{abc: 123, def: 456})
+
+    assert scene.assigns == %{abc: :original, def: 456}
+  end
+
   test "get gets a value from assigns - works like map", %{scene: scene} do
     scene =
       Scene.assign(scene,


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description

<!--- Describe your changes in detail -->

Building on the previous work allows `assign_new/2` to work with either a keyword list or map.

The change is applied to `Driver` and `Scene` so both have a consistent API.

## Motivation and Context

Consistency in the API is essential in line with the recent work of `assign/2` taking a list or map.

Thanks to @amclain and @thejohncotton for the inspiration.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
