### PR TITLE
add note about request_input in upgrade guide

### DIFF
--- a/guides/upgrading_to_v0.11.md
+++ b/guides/upgrading_to_v0.11.md
@@ -28,6 +28,7 @@ This guide is a good first pass. If you see things that need improving, please c
     * The `:clear_color` style (which was always weird) is gone. You can now set a theme on the viewport (in config), which sets the background color.
     * The SceneRef primitive is gone, and replaced with a combination of Component and Script primitives.
     * The `:font_blur` primitive is gone. Sorry. Didn't have a close enough analog in Canvas
+    * Input events are no longer implicitly requested for a scene. You can explicitly request the input events you want using `Scene.request_input/2` or `Scene.capture_input/2`
     * The format of the input messages have changed - see the docs
     * The optional styles on some of the standard components (Button) have changed to be more consistent with the standard styles. See documentation.
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description
Adding a note about how requesting input has changed to the upgrade guide.

## Motivation and Context

The change in requesting input events for a scene from implicit in 0.10 to explicit in 0.11 upgrade was not 100% clear from the upgrade guide. Based on the discussion in slack I think this may be a small improvement to help folks during the upgrade. I'm not 100% sure where else it may be useful to add documentation for this but I am happy to add some with the appropriate guidance.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
