### PR TITLE
New component events

### DIFF
--- a/lib/scenic/component/button.ex
+++ b/lib/scenic/component/button.ex
@@ -296,9 +296,10 @@ defmodule Scenic.Component.Button do
   def handle_input(
         {:cursor_button, {:btn_left, 1, _, _}},
         :btn,
-        %Scene{assigns: %{graph: graph, theme: theme}} = scene
+        %Scene{assigns: %{id: id, graph: graph, theme: theme}} = scene
       ) do
     :ok = capture_input(scene, :cursor_button)
+    :ok = send_parent_event(scene, {:btn_pressed, id})
 
     graph = update_color(graph, theme, true)
 
@@ -340,6 +341,7 @@ defmodule Scenic.Component.Button do
       ) do
     :ok = release_input(scene)
     :ok = send_parent_event(scene, {:click, id})
+    :ok = send_parent_event(scene, {:btn_released, id})
 
     graph = update_color(graph, theme, false)
 

--- a/lib/scenic/component/button.ex
+++ b/lib/scenic/component/button.ex
@@ -22,7 +22,16 @@ defmodule Scenic.Component.Button do
   If a button press is successful, it sends an event message to the host scene
   in the form of:
 
-      {:click, id}
+      `{:click, id}`
+
+  This event is only sent after the button is released. There're also, though,
+  two other events that you can receive:
+
+      `{:btn_pressed, id}`
+
+  and
+
+      `{:btn_released, id}`
 
   These messages can be received and handled in your scene via
   `c:Scenic.Scene.handle_event/3`. For example:

--- a/lib/scenic/component/input/dropdown.ex
+++ b/lib/scenic/component/input/dropdown.ex
@@ -441,6 +441,8 @@ defmodule Scenic.Component.Input.Dropdown do
     # set the appropriate hilighting for each of the items
     graph = update_highlighting(graph, items, selected_id, id, theme)
 
+    :ok = send_parent_event(scene, {:dropdown_item_hover, id})
+
     scene =
       scene
       |> assign(hover_id: nil, graph: graph)
@@ -453,10 +455,12 @@ defmodule Scenic.Component.Input.Dropdown do
   def handle_input(
         {:cursor_button, {:btn_left, 1, _, _}},
         @button_id,
-        %Scene{assigns: %{down: false, graph: graph, rotate_caret: rotate_caret}} = scene
+        %Scene{assigns: %{down: false, graph: graph, id: id, rotate_caret: rotate_caret}} = scene
       ) do
     # capture input
     :ok = capture_input(scene, [:cursor_button, :cursor_pos])
+
+    :ok = send_parent_event(scene, {:dropdown_opened, id})
 
     # drop the menu
     graph =
@@ -483,6 +487,7 @@ defmodule Scenic.Component.Input.Dropdown do
             theme: theme,
             items: items,
             graph: graph,
+            id: id,
             selected_id: selected_id
           }
         } = scene
@@ -495,6 +500,8 @@ defmodule Scenic.Component.Input.Dropdown do
       |> Graph.modify(@dropbox_id, &update_opts(&1, hidden: true))
 
     :ok = release_input(scene)
+
+    :ok = send_parent_event(scene, {:dropdown_closed, id})
 
     scene =
       scene

--- a/lib/scenic/component/input/dropdown.ex
+++ b/lib/scenic/component/input/dropdown.ex
@@ -31,6 +31,12 @@ defmodule Scenic.Component.Input.Dropdown do
 
   `{:value_changed, id, selected_item_id}`
 
+  It also send the following events:
+
+  `{:dropdown_opened, id}` - sent when the dropdown opens
+  `{:dropdown_closed, id}` - sent when the dropdown closes
+  `{:dropdown_item_hover, id, item_id}` - sent when and item is hovered
+
   ## Options
 
   Dropdowns honor the following list of options.
@@ -431,6 +437,7 @@ defmodule Scenic.Component.Input.Dropdown do
         %Scene{
           assigns: %{
             down: true,
+            id: component_id,
             items: items,
             graph: graph,
             selected_id: selected_id,
@@ -441,7 +448,7 @@ defmodule Scenic.Component.Input.Dropdown do
     # set the appropriate hilighting for each of the items
     graph = update_highlighting(graph, items, selected_id, id, theme)
 
-    :ok = send_parent_event(scene, {:dropdown_item_hover, id})
+    :ok = send_parent_event(scene, {:dropdown_item_hover, component_id, id})
 
     scene =
       scene

--- a/lib/scenic/component/input/text_field.ex
+++ b/lib/scenic/component/input/text_field.ex
@@ -22,8 +22,8 @@ defmodule Scenic.Component.Input.TextField do
 
   It also sends other two events when focus is gained or lost, respectively:
 
-  `{:focus_in, id}`
-  `{:focus_out, id}`
+  `{:focus, id}`
+  `{:blur, id}`
 
   ## Styles
 
@@ -262,7 +262,7 @@ defmodule Scenic.Component.Input.TextField do
   defp capture_focus(%{assigns: %{focused: false, graph: graph, id: id, theme: theme}} = scene) do
     # capture the input
     capture_input(scene, @input_capture)
-    :ok = send_parent_event(scene, {:focus_in, id})
+    :ok = send_parent_event(scene, {:focus, id})
 
     # start animating the caret
     cast_children(scene, :start_caret)
@@ -283,7 +283,7 @@ defmodule Scenic.Component.Input.TextField do
   defp release_focus(%{assigns: %{focused: true, graph: graph, id: id, theme: theme}} = scene) do
     # release the input
     release_input(scene)
-    :ok = send_parent_event(scene, {:focus_out, id})
+    :ok = send_parent_event(scene, {:blur, id})
 
     # stop animating the caret
     cast_children(scene, :stop_caret)

--- a/lib/scenic/component/input/text_field.ex
+++ b/lib/scenic/component/input/text_field.ex
@@ -20,6 +20,11 @@ defmodule Scenic.Component.Input.TextField do
 
   `{:value_changed, id, value}`
 
+  It also sends other two events when focus is gained or lost, respectively:
+
+  `{:focus_in, id}`
+  `{:focus_out, id}`
+
   ## Styles
 
   Text fields honor the following styles

--- a/lib/scenic/component/input/text_field.ex
+++ b/lib/scenic/component/input/text_field.ex
@@ -254,9 +254,10 @@ defmodule Scenic.Component.Input.TextField do
   end
 
   # --------------------------------------------------------
-  defp capture_focus(%{assigns: %{focused: false, graph: graph, theme: theme}} = scene) do
+  defp capture_focus(%{assigns: %{focused: false, graph: graph, id: id, theme: theme}} = scene) do
     # capture the input
     capture_input(scene, @input_capture)
+    :ok = send_parent_event(scene, {:focus_in, id})
 
     # start animating the caret
     cast_children(scene, :start_caret)
@@ -274,9 +275,10 @@ defmodule Scenic.Component.Input.TextField do
   end
 
   # --------------------------------------------------------
-  defp release_focus(%{assigns: %{focused: true, graph: graph, theme: theme}} = scene) do
+  defp release_focus(%{assigns: %{focused: true, graph: graph, id: id, theme: theme}} = scene) do
     # release the input
     release_input(scene)
+    :ok = send_parent_event(scene, {:focus_out, id})
 
     # stop animating the caret
     cast_children(scene, :stop_caret)

--- a/test/scenic/component/button_test.exs
+++ b/test/scenic/component/button_test.exs
@@ -83,15 +83,22 @@ defmodule Scenic.Component.ButtonTest do
     refute_receive(_, 10)
   end
 
-  test "Press in and release in sends the event", %{vp: vp} do
+  test "Press in and release in sends 'click' and 'btn_released' events", %{vp: vp} do
     Input.send(vp, @press_in)
     Input.send(vp, @release_in)
     assert_receive({:fwd_event, {:click, :test_btn}}, 200)
+    assert_receive({:fwd_event, {:btn_released, :test_btn}}, 200)
+  end
+
+  test "Press in sends a btn_pressed event", %{vp: vp} do
+    Input.send(vp, @press_in)
+    assert_receive({:fwd_event, {:btn_pressed, :test_btn}}, 200)
   end
 
   test "Press in and release out does not send the event", %{vp: vp} do
     Input.send(vp, @press_in)
     Input.send(vp, @release_out)
+    assert_receive({:fwd_event, {:btn_pressed, :test_btn}}, 10)
     refute_receive(_, 10)
   end
 

--- a/test/scenic/component/input/dropdown_test.exs
+++ b/test/scenic/component/input/dropdown_test.exs
@@ -170,11 +170,11 @@ defmodule Scenic.Component.Input.DropdownTest do
 
     Input.send(vp, @hover_a)
     force_sync(vp.pid, comp_pid)
-    assert_receive({:fwd_event, {:dropdown_item_hover, 1}}, 100)
+    assert_receive({:fwd_event, {:dropdown_item_hover, :dropdown, 1}}, 100)
 
     Input.send(vp, @hover_b)
     force_sync(vp.pid, comp_pid)
-    assert_receive({:fwd_event, {:dropdown_item_hover, 2}}, 100)
+    assert_receive({:fwd_event, {:dropdown_item_hover, :dropdown, 2}}, 100)
 
     refute_receive(_, 10)
   end

--- a/test/scenic/component/input/dropdown_test.exs
+++ b/test/scenic/component/input/dropdown_test.exs
@@ -29,6 +29,9 @@ defmodule Scenic.Component.Input.DropdownTest do
   @press_out {:cursor_button, {:btn_left, 1, [], {1000, 1000}}}
   @release_out {:cursor_button, {:btn_left, 1, [], {1000, 1000}}}
 
+  @hover_a {:cursor_pos, {20, 50}}
+  @hover_b {:cursor_pos, {20, 80}}
+
   defmodule TestScene do
     use Scenic.Scene
     import Scenic.Components
@@ -90,13 +93,18 @@ defmodule Scenic.Component.Input.DropdownTest do
     assert_receive({:fwd_event, {:value_changed, :dropdown, 1}}, 100)
   end
 
-  test "press_in/release_in/press_in does nothing", %{vp: vp, comp_pid: comp_pid} do
+  test "press_in/release_in/press_in will fire open and close events", %{
+    vp: vp,
+    comp_pid: comp_pid
+  } do
     Input.send(vp, @press_in)
     force_sync(vp.pid, comp_pid)
     Input.send(vp, @release_in)
     force_sync(vp.pid, comp_pid)
-    Input.send(vp, @press_in)
+    assert_receive({:fwd_event, {:dropdown_opened, :dropdown}}, 100)
 
+    Input.send(vp, @press_in)
+    assert_receive({:fwd_event, {:dropdown_closed, :dropdown}}, 100)
     refute_receive(_, 10)
   end
 
@@ -119,6 +127,8 @@ defmodule Scenic.Component.Input.DropdownTest do
     force_sync(vp.pid, comp_pid)
     Input.send(vp, @release_in)
     force_sync(vp.pid, comp_pid)
+    assert_receive({:fwd_event, {:dropdown_opened, :dropdown}}, 100)
+
     Input.send(vp, @press_a)
     assert_receive({:fwd_event, {:value_changed, :dropdown, 1}}, 100)
   end
@@ -128,15 +138,18 @@ defmodule Scenic.Component.Input.DropdownTest do
     force_sync(vp.pid, comp_pid)
     Input.send(vp, @release_in)
     force_sync(vp.pid, comp_pid)
+    assert_receive({:fwd_event, {:dropdown_opened, :dropdown}}, 100)
+
     Input.send(vp, @press_b)
     assert_receive({:fwd_event, {:value_changed, :dropdown, 2}}, 100)
   end
 
-  test "Press in and release out does not send the event", %{vp: vp, comp_pid: comp_pid} do
+  test "Press in and release out send only opened event", %{vp: vp, comp_pid: comp_pid} do
     Input.send(vp, @press_in)
     force_sync(vp.pid, comp_pid)
-    Input.send(vp, @release_out)
+    assert_receive({:fwd_event, {:dropdown_opened, :dropdown}}, 100)
 
+    Input.send(vp, @release_out)
     refute_receive(_, 10)
   end
 
@@ -144,6 +157,24 @@ defmodule Scenic.Component.Input.DropdownTest do
     Input.send(vp, @press_out)
     force_sync(vp.pid, comp_pid)
     Input.send(vp, @release_in)
+
+    refute_receive(_, 10)
+  end
+
+  test "", %{vp: vp, comp_pid: comp_pid} do
+    Input.send(vp, @press_in)
+    force_sync(vp.pid, comp_pid)
+    Input.send(vp, @release_in)
+    force_sync(vp.pid, comp_pid)
+    assert_receive({:fwd_event, {:dropdown_opened, :dropdown}}, 100)
+
+    Input.send(vp, @hover_a)
+    force_sync(vp.pid, comp_pid)
+    assert_receive({:fwd_event, {:dropdown_item_hover, 1}}, 100)
+
+    Input.send(vp, @hover_b)
+    force_sync(vp.pid, comp_pid)
+    assert_receive({:fwd_event, {:dropdown_item_hover, 2}}, 100)
 
     refute_receive(_, 10)
   end

--- a/test/scenic/component/input/text_field_test.exs
+++ b/test/scenic/component/input/text_field_test.exs
@@ -94,29 +94,29 @@ defmodule Scenic.Component.Input.TextFieldTest do
     :_pong_ = GenServer.call(vp_pid, :_ping_)
   end
 
-  test "press_in captures, starts editing and fire focus_in event", %{vp: vp, pid: pid} do
+  test "press_in captures, starts editing and fire focus event", %{vp: vp, pid: pid} do
     assert Input.fetch_captures!(vp) == {:ok, []}
     Input.send(vp, @press_in)
     force_sync(vp.pid, pid)
 
     assert Input.fetch_captures!(vp) ~> {:ok, sorted_list([:codepoint, :cursor_button, :key])}
-    assert_receive({:fwd_event, {:focus_in, :text_field}}, 200)
+    assert_receive({:fwd_event, {:focus, :text_field}}, 200)
 
     Input.send(vp, @cp_k)
     assert_receive({:fwd_event, {:value_changed, :text_field, "kInitial value"}}, 200)
   end
 
-  test "press_out releases, ends editing and fire focus_out event", %{vp: vp, pid: pid} do
+  test "press_out releases, ends editing and fire blur event", %{vp: vp, pid: pid} do
     Input.send(vp, @press_in)
     force_sync(vp.pid, pid)
 
     assert Input.fetch_captures!(vp) ~> {:ok, sorted_list([:codepoint, :cursor_button, :key])}
-    assert_receive({:fwd_event, {:focus_in, :text_field}}, 200)
+    assert_receive({:fwd_event, {:focus, :text_field}}, 200)
 
     Input.send(vp, @press_out)
     force_sync(vp.pid, pid)
     assert Input.fetch_captures!(vp) == {:ok, []}
-    assert_receive({:fwd_event, {:focus_out, :text_field}}, 200)
+    assert_receive({:fwd_event, {:blur, :text_field}}, 200)
 
     Input.send(vp, @cp_k)
     refute_receive(_, 10)
@@ -125,7 +125,7 @@ defmodule Scenic.Component.Input.TextFieldTest do
   test "pressing in the field moves the cursor to the nearst character gap", %{vp: vp, pid: pid} do
     Input.send(vp, @press_in)
     force_sync(vp.pid, pid)
-    assert_receive({:fwd_event, {:focus_in, :text_field}}, 200)
+    assert_receive({:fwd_event, {:focus, :text_field}}, 200)
 
     Input.send(vp, @cp_k)
     assert_receive({:fwd_event, {:value_changed, :text_field, "kInitial value"}}, 200)
@@ -206,7 +206,7 @@ defmodule Scenic.Component.Input.TextFieldTest do
   test "backspace does nothing at the start of the string", %{vp: vp, pid: pid} do
     Input.send(vp, @press_in)
     force_sync(vp.pid, pid)
-    assert_receive({:fwd_event, {:focus_in, :text_field}}, 200)
+    assert_receive({:fwd_event, {:focus, :text_field}}, 200)
 
     Input.send(vp, @key_backspace)
     refute_receive(_, 10)
@@ -223,7 +223,7 @@ defmodule Scenic.Component.Input.TextFieldTest do
   test "delete does nothing at the end of the field", %{vp: vp, pid: pid} do
     Input.send(vp, @press_in)
     force_sync(vp.pid, pid)
-    assert_receive({:fwd_event, {:focus_in, :text_field}}, 200)
+    assert_receive({:fwd_event, {:focus, :text_field}}, 200)
 
     Input.send(vp, @key_end)
     Input.send(vp, @key_delete)
@@ -236,7 +236,7 @@ defmodule Scenic.Component.Input.TextFieldTest do
 
     Input.send(vp, {:cursor_button, {:btn_left, 1, [], {20, 60}}})
     force_sync(vp.pid, pid)
-    assert_receive({:fwd_event, {:focus_in, :number_field}}, 200)
+    assert_receive({:fwd_event, {:focus, :number_field}}, 200)
 
     Input.send(vp, {:codepoint, {"a", []}})
     refute_receive(_, 10)
@@ -256,7 +256,7 @@ defmodule Scenic.Component.Input.TextFieldTest do
 
     Input.send(vp, {:cursor_button, {:btn_left, 1, [], {14, 86}}})
     force_sync(vp.pid, pid)
-    assert_receive({:fwd_event, {:focus_in, :integer_field}}, 200)
+    assert_receive({:fwd_event, {:focus, :integer_field}}, 200)
 
     Input.send(vp, {:codepoint, {"a", []}})
     refute_receive(_, 10)
@@ -276,7 +276,7 @@ defmodule Scenic.Component.Input.TextFieldTest do
 
     Input.send(vp, {:cursor_button, {:btn_left, 1, [], {14, 121}}})
     force_sync(vp.pid, pid)
-    assert_receive({:fwd_event, {:focus_in, :abcdefg_field}}, 200)
+    assert_receive({:fwd_event, {:focus, :abcdefg_field}}, 200)
 
     Input.send(vp, {:codepoint, {"a", []}})
     assert_receive({:fwd_event, {:value_changed, :abcdefg_field, "a"}}, 200)
@@ -294,7 +294,7 @@ defmodule Scenic.Component.Input.TextFieldTest do
 
     Input.send(vp, {:cursor_button, {:btn_left, 1, [], {14, 171}}})
     force_sync(vp.pid, pid)
-    assert_receive({:fwd_event, {:focus_in, :fn_field}}, 200)
+    assert_receive({:fwd_event, {:focus, :fn_field}}, 200)
 
     Input.send(vp, {:codepoint, {"a", []}})
     refute_receive(_, 10)

--- a/test/scenic/component/input/text_field_test.exs
+++ b/test/scenic/component/input/text_field_test.exs
@@ -94,25 +94,29 @@ defmodule Scenic.Component.Input.TextFieldTest do
     :_pong_ = GenServer.call(vp_pid, :_ping_)
   end
 
-  test "press_in captures and starts editing", %{vp: vp, pid: pid} do
+  test "press_in captures, starts editing and fire focus_in event", %{vp: vp, pid: pid} do
     assert Input.fetch_captures!(vp) == {:ok, []}
     Input.send(vp, @press_in)
     force_sync(vp.pid, pid)
+
     assert Input.fetch_captures!(vp) ~> {:ok, sorted_list([:codepoint, :cursor_button, :key])}
+    assert_receive({:fwd_event, {:focus_in, :text_field}}, 200)
 
     Input.send(vp, @cp_k)
     assert_receive({:fwd_event, {:value_changed, :text_field, "kInitial value"}}, 200)
   end
 
-  test "press_out releases and ends editing", %{vp: vp, pid: pid} do
+  test "press_out releases, ends editing and fire focus_out event", %{vp: vp, pid: pid} do
     Input.send(vp, @press_in)
     force_sync(vp.pid, pid)
 
     assert Input.fetch_captures!(vp) ~> {:ok, sorted_list([:codepoint, :cursor_button, :key])}
+    assert_receive({:fwd_event, {:focus_in, :text_field}}, 200)
 
     Input.send(vp, @press_out)
     force_sync(vp.pid, pid)
     assert Input.fetch_captures!(vp) == {:ok, []}
+    assert_receive({:fwd_event, {:focus_out, :text_field}}, 200)
 
     Input.send(vp, @cp_k)
     refute_receive(_, 10)
@@ -121,6 +125,7 @@ defmodule Scenic.Component.Input.TextFieldTest do
   test "pressing in the field moves the cursor to the nearst character gap", %{vp: vp, pid: pid} do
     Input.send(vp, @press_in)
     force_sync(vp.pid, pid)
+    assert_receive({:fwd_event, {:focus_in, :text_field}}, 200)
 
     Input.send(vp, @cp_k)
     assert_receive({:fwd_event, {:value_changed, :text_field, "kInitial value"}}, 200)
@@ -201,6 +206,7 @@ defmodule Scenic.Component.Input.TextFieldTest do
   test "backspace does nothing at the start of the string", %{vp: vp, pid: pid} do
     Input.send(vp, @press_in)
     force_sync(vp.pid, pid)
+    assert_receive({:fwd_event, {:focus_in, :text_field}}, 200)
 
     Input.send(vp, @key_backspace)
     refute_receive(_, 10)
@@ -217,6 +223,7 @@ defmodule Scenic.Component.Input.TextFieldTest do
   test "delete does nothing at the end of the field", %{vp: vp, pid: pid} do
     Input.send(vp, @press_in)
     force_sync(vp.pid, pid)
+    assert_receive({:fwd_event, {:focus_in, :text_field}}, 200)
 
     Input.send(vp, @key_end)
     Input.send(vp, @key_delete)
@@ -229,6 +236,7 @@ defmodule Scenic.Component.Input.TextFieldTest do
 
     Input.send(vp, {:cursor_button, {:btn_left, 1, [], {20, 60}}})
     force_sync(vp.pid, pid)
+    assert_receive({:fwd_event, {:focus_in, :number_field}}, 200)
 
     Input.send(vp, {:codepoint, {"a", []}})
     refute_receive(_, 10)
@@ -248,6 +256,7 @@ defmodule Scenic.Component.Input.TextFieldTest do
 
     Input.send(vp, {:cursor_button, {:btn_left, 1, [], {14, 86}}})
     force_sync(vp.pid, pid)
+    assert_receive({:fwd_event, {:focus_in, :integer_field}}, 200)
 
     Input.send(vp, {:codepoint, {"a", []}})
     refute_receive(_, 10)
@@ -267,6 +276,7 @@ defmodule Scenic.Component.Input.TextFieldTest do
 
     Input.send(vp, {:cursor_button, {:btn_left, 1, [], {14, 121}}})
     force_sync(vp.pid, pid)
+    assert_receive({:fwd_event, {:focus_in, :abcdefg_field}}, 200)
 
     Input.send(vp, {:codepoint, {"a", []}})
     assert_receive({:fwd_event, {:value_changed, :abcdefg_field, "a"}}, 200)
@@ -284,6 +294,7 @@ defmodule Scenic.Component.Input.TextFieldTest do
 
     Input.send(vp, {:cursor_button, {:btn_left, 1, [], {14, 171}}})
     force_sync(vp.pid, pid)
+    assert_receive({:fwd_event, {:focus_in, :fn_field}}, 200)
 
     Input.send(vp, {:codepoint, {"a", []}})
     refute_receive(_, 10)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description
This PR adds new events to the following built in components:

 - `Scenic.Component.Button`
    - `{:btn_pressed, id}` - sent when a button is pressed
    - `{:btn_released, id}` - sent after the button is released
 
 - `Scenic.Component.Input.TextField`
    - `{:focus, id}` - sent when a text field is "active", i.e., is ready to receive inputs
    - `{:blur, id}` - sent when a text field becomes "inactive", i.e., will not receive inputs


 - `Scenic.Component.Input.Dropdown`
    - `{:dropdown_opened, id}` - sent when the dropdown opens
    - `{:dropdown_closed, id}` - sent when the dropdown closes
    - `{:dropdown_item_hover, id, item_id}` - sent when and item is hovered

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Those new events are very helpful in certain scenarios.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
