### PR TITLE
Warns missing `handle_input/3` on `request_input/2`

### DIFF
--- a/lib/scenic/scene.ex
+++ b/lib/scenic/scene.ex
@@ -722,7 +722,10 @@ defmodule Scenic.Scene do
   def request_input(scene, input_class)
   def request_input(scene, input) when is_atom(input), do: request_input(scene, [input])
 
-  def request_input(%Scene{viewport: vp, pid: pid}, inputs) when is_list(inputs) do
+  def request_input(%Scene{viewport: vp, pid: pid, module: module}, inputs) when is_list(inputs) do
+    unless Kernel.function_exported?(module, :handle_input, 3) do
+      Logger.warn("Requesting input for #{inspect inputs} - #{module}.handle_input/3 not implemented")
+    end
     ViewPort.Input.request(vp, inputs, pid: pid)
   end
 

--- a/test/scenic/view_port/input_test.exs
+++ b/test/scenic/view_port/input_test.exs
@@ -27,6 +27,10 @@ defmodule Scenic.ViewPort.InputTest do
     # def handle_input( input, %{assigns: %{pid: pid}} = scene ) do
     #   Process.send( pid, {:test_input, input}, [] )
     # end
+
+    def handle_input(_, _, scene) do
+      {:noreply, scene}
+    end
   end
 
   setup do


### PR DESCRIPTION
## Description

I didn’t want development workflows or older projects to break, so I thought a warning would be an excellent solution to reduce the debugging time but still allow current projects to continue working with this enhancement. This means it is still possible to implement the wrong callback, but hopefully, the warning will point the developer in the right direction and save minutes, if not hours, of debugging.

## Motivation and Context

With all the different handlers for events, inputs, and messages, it can be simple to pick the wrong one when implementing. This leads to bugs that are difficult to find.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
