### PR TITLE
Improve static assets otp_app error message

### DIFF
--- a/lib/scenic/assets/static.ex
+++ b/lib/scenic/assets/static.ex
@@ -451,10 +451,12 @@ defmodule Scenic.Assets.Static do
         |> :code.lib_dir()
         |> Path.join(Static.dst_dir())
       rescue
-        _ ->
-          raise """
-          'use Scenic.Assets.Static' requires a valid :otp_app option.
-          """
+        e ->
+          Logger.warn(
+            "'use Scenic.Assets.Static' requires a valid :otp_app option. Received otp_app #{opts[:otp_app]}"
+          )
+
+          reraise e, __STACKTRACE__
       end
 
     # make sure the destination directory exists (delete and recreate to keep it clean)


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description

Changes the error message raised when `Scenic.Assets.Static.build!/2` encounters an error.

## Motivation and Context

Previously it wasn't possible to know the specific error message which could potentially cover up other error messages. Also knowing the value that was tried gives a good hint about if you are setting the value in your configuration in the right place.

Hopefully this change will help user's debug errors in their assets `otp_app` configuration.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
