### PR TITLE
Enforce PR title length in a GitHub Action3

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,4 +34,3 @@ boxes that apply: -->
 apply. -->
 
 - [ ] Check other PRs and make sure that the changes are not done yet.
-- [ ] The PR title is no longer than 64 characters.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,16 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  test:
+    name: PR Title
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: deepakputhraya/action-pr-title@master
+      with:
+        max_length: 64 # Max length of the title
+        github_token: ${{ github.token }} # Default: ${{ github.token }}


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description

Enforce the PR title length in a GitHub action instead of as a checklist item

Uses https://github.com/marketplace/actions/pull-request-title-rules
<!--- Describe your changes in detail -->

## Motivation and Context

I got tired of manually checking the length of PR titles when this should be something that the computer is able to enforce for us.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
- [x] The PR title is no longer than 64 characters.
