### PR TITLE
New function Scenic.Script.arc/7 to add arcs to current path

### DIFF
--- a/test/scenic/script_test.exs
+++ b/test/scenic/script_test.exs
@@ -351,6 +351,12 @@ defmodule Scenic.ScriptTest do
     assert expected == Script.serialize(expected) |> Script.deserialize()
   end
 
+  test "arc works" do
+    expected = [{:arc, {0.0, 0.0, 5.0, 0.0, 6.0, 1}}]
+    assert Script.arc([], 0, 0, 5, 0, 6, 1) == expected
+    assert expected == Script.serialize(expected) |> Script.deserialize()
+  end
+
   # --------------------------------------------------------
   # transform commands
 


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description

This PR adds a new operation arc to add arcs to current path.
This interface is also available on HTML Canvas API: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/arc


## Motivation and Context

Today we only have 2 interfaces to have arcs:

- `Scenic.Script.draw_arc/4`: which draws an arc on a new path;
- `Scenic.Script.arc_to/6`: which adds an arc on the current path.
The need for a third arc operation is that none of the above functions provide a flexible interface for arcs as the nvgArc does.

So this new function arc have the same parameters as nvgArc, which gives a more flexible interface for drawing arcs.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.

## Dependencies

This PR depends on changes on https://github.com/ScenicFramework/scenic_driver_local and can only be merged after https://github.com/ScenicFramework/scenic_driver_local/pull/42