### PR TITLE
Fix Elixir 1.15 warnings

### DIFF
--- a/lib/scenic/assets/static.ex
+++ b/lib/scenic/assets/static.ex
@@ -452,7 +452,7 @@ defmodule Scenic.Assets.Static do
         |> Path.join(Static.dst_dir())
       rescue
         e ->
-          Logger.warn(
+          Logger.warning(
             "'use Scenic.Assets.Static' requires a valid :otp_app option. Received otp_app #{opts[:otp_app]}"
           )
 
@@ -583,7 +583,7 @@ defmodule Scenic.Assets.Static do
         assign(lib, :aliases, new_alias, hash)
 
       _ ->
-        Logger.warn("Attempted to alias #{inspect(new_alias)} to unknown asset: #{inspect(to)}")
+        Logger.warning("Attempted to alias #{inspect(new_alias)} to unknown asset: #{inspect(to)}")
         lib
     end
   end

--- a/lib/scenic/component/input/checkbox.ex
+++ b/lib/scenic/component/input/checkbox.ex
@@ -315,7 +315,7 @@ defmodule Scenic.Component.Input.Checkbox do
   end
 
   def handle_put(v, %{assigns: %{id: id}} = scene) do
-    Logger.warn(
+    Logger.warning(
       "Attempted to put an invalid value on Checkbox id: #{inspect(id)}, value: #{inspect(v)}"
     )
 

--- a/lib/scenic/component/input/dropdown.ex
+++ b/lib/scenic/component/input/dropdown.ex
@@ -678,7 +678,7 @@ defmodule Scenic.Component.Input.Dropdown do
     scene =
       case Enum.find(items, fn {_, id} -> id == s_id end) do
         nil ->
-          Logger.warn(
+          Logger.warning(
             "Attempted to put an invalid value on Dropdown id: #{inspect(id)}, value: #{inspect(s_id)}"
           )
 
@@ -709,7 +709,7 @@ defmodule Scenic.Component.Input.Dropdown do
   end
 
   def handle_put(v, %{assigns: %{id: id}} = scene) do
-    Logger.warn(
+    Logger.warning(
       "Attempted to put an invalid value on Dropdown id: #{inspect(id)}, value: #{inspect(v)}"
     )
 

--- a/lib/scenic/component/input/radio_button.ex
+++ b/lib/scenic/component/input/radio_button.ex
@@ -302,7 +302,7 @@ defmodule Scenic.Component.Input.RadioButton do
   end
 
   def handle_put(v, %{assigns: %{id: id}} = scene) do
-    Logger.warn(
+    Logger.warning(
       "Attempted to put an invalid value on Radio Button id: #{inspect(id)}, value: #{inspect(v)}"
     )
 

--- a/lib/scenic/component/input/radio_group.ex
+++ b/lib/scenic/component/input/radio_group.ex
@@ -267,7 +267,7 @@ defmodule Scenic.Component.Input.RadioGroup do
     scene =
       case Enum.find(items, fn {_, id} -> id == value end) do
         nil ->
-          Logger.warn(
+          Logger.warning(
             "Attempted to put an invalid value on Radio Group id: #{inspect(id)}, value: #{inspect(value)}"
           )
 
@@ -284,7 +284,7 @@ defmodule Scenic.Component.Input.RadioGroup do
   end
 
   def handle_put(v, %{assigns: %{id: id}} = scene) do
-    Logger.warn(
+    Logger.warning(
       "Attempted to put an invalid value on Dropdown id: #{inspect(id)}, value: #{inspect(v)}"
     )
 

--- a/lib/scenic/component/input/slider.ex
+++ b/lib/scenic/component/input/slider.ex
@@ -392,7 +392,7 @@ defmodule Scenic.Component.Input.Slider do
     scene =
       case Enum.member?(extents, value) do
         false ->
-          Logger.warn(
+          Logger.warning(
             "Attempted to put an invalid value on Slider id: #{inspect(id)}, value: #{inspect(value)}"
           )
 
@@ -444,7 +444,7 @@ defmodule Scenic.Component.Input.Slider do
   end
 
   def handle_put(v, %{assigns: %{id: id}} = scene) do
-    Logger.warn(
+    Logger.warning(
       "Attempted to put an invalid value on Slider id: #{inspect(id)}, value: #{inspect(v)}"
     )
 

--- a/lib/scenic/component/input/text_field.ex
+++ b/lib/scenic/component/input/text_field.ex
@@ -775,7 +775,7 @@ defmodule Scenic.Component.Input.TextField do
   end
 
   def handle_put(v, %{assigns: %{id: id}} = scene) do
-    Logger.warn(
+    Logger.warning(
       "Attempted to put an invalid value on TextField id: #{inspect(id)}, value: #{inspect(v)}"
     )
 

--- a/lib/scenic/component/input/toggle.ex
+++ b/lib/scenic/component/input/toggle.ex
@@ -373,7 +373,7 @@ defmodule Scenic.Component.Input.Toggle do
   end
 
   def handle_put(v, %{assigns: %{id: id}} = scene) do
-    Logger.warn(
+    Logger.warning(
       "Attempted to put an invalid value on Toggle id: #{inspect(id)}, value: #{inspect(v)}"
     )
 

--- a/lib/scenic/driver.ex
+++ b/lib/scenic/driver.ex
@@ -408,7 +408,7 @@ defmodule Scenic.Driver do
         %Driver{input_limited: true, input_buffer: buffer} = driver,
         {class, _} = input
       ) do
-    # Logger.warn( "input_limited #{inspect({input})}" )
+    # Logger.warning( "input_limited #{inspect({input})}" )
     case class do
       :cursor_pos -> %{driver | input_buffer: Map.put(buffer, class, input)}
       :cursor_scroll -> %{driver | input_buffer: Map.put(buffer, class, input)}
@@ -421,7 +421,7 @@ defmodule Scenic.Driver do
         %Driver{limit_ms: limit_ms} = driver,
         {class, _} = input
       ) do
-    # Logger.warn( "input #{inspect({input})}" )
+    # Logger.warning( "input #{inspect({input})}" )
     case class do
       :cursor_pos ->
         Process.send_after(self(), @input_limiter, limit_ms)

--- a/lib/scenic/scene.ex
+++ b/lib/scenic/scene.ex
@@ -595,7 +595,7 @@ defmodule Scenic.Scene do
 
             _ ->
               # invalid data. log a warning
-              Logger.warn(
+              Logger.warning(
                 "Attempted to update component with invalid data. id: #{inspect(id)}, data: #{inspect(new_value)}"
               )
 

--- a/lib/scenic/script.ex
+++ b/lib/scenic/script.ex
@@ -118,7 +118,7 @@ defmodule Scenic.Script do
   Building and using a custom script happens in three parts. First, the script itself
   is created using the `Scenic.Script` api.
 
-  Then the script is published to the ViewPort using `Scenic.Scene/push_script/4` with a
+  Then the script is published to the ViewPort using `Scenic.Scene.push_script/4` with a
   unique name.
 
   Later, the graph for the checkbox references this script, which is what triggers it to be drawn.


### PR DESCRIPTION
## Description

Fix Elixir 1.15 warnings and a typo in the docs (caught with the in-progress https://github.com/elixir-lang/ex_doc/pull/1564)

## Motivation and Context

Allows users to not have to scroll through unrelated errors.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
