### PR TITLE
find should always return a full primitive

### DIFF
--- a/lib/scenic/graph.ex
+++ b/lib/scenic/graph.ex
@@ -585,10 +585,9 @@ defmodule Scenic.Graph do
   @spec find(graph :: t(), (any -> as_boolean(term()))) :: list(Primitive.t())
   def find(graph, finder)
 
-  # pass in an atom based id, and it will transform all mapped uids
-  def find(%__MODULE__{} = graph, finder) when is_function(finder, 1) do
+  def find(%__MODULE__{} = graph, finder) do
     reduce(graph, [], fn p, acc ->
-      Map.get(p, :id)
+      p
       |> finder.()
       |> case do
         true -> [p | acc]


### PR DESCRIPTION


## Description

Changes `Graph.find/2` to pass a full primitive instead of just the primitive's id to the finder function.

## Motivation and Context

According to the docs, this should pass a full primitive.

## Types of changes

This could potentially break other code using `Graph.find/2` currently expecting a primitive id.