### PR TITLE
Remove references to old master branch

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Guidelines for bug reports:
    reported.
 
 2. **Check if the issue has been fixed** &mdash; try to reproduce it using the
-   `master` branch in the repository.
+   `main` branch in the repository.
 
 3. **Isolate and report the problem** &mdash; ideally, create a reduced test
    case.
@@ -165,16 +165,16 @@ excellent pull request:
    your fork:
 
    ```bash
-   git checkout master
-   git pull upstream master
+   git checkout main
+   git pull upstream main
    git push
    ```
 
-3. Create a new topic branch (off of `master`) to contain your feature, change,
+3. Create a new topic branch (off of `main`) to contain your feature, change,
    or fix.
 
-   **IMPORTANT**: Making changes in `master` is discouraged. You should always
-   keep your local `master` in sync with upstream `master` and make your
+   **IMPORTANT**: Making changes in `main` is discouraged. You should always
+   keep your local `main` in sync with upstream `main` and make your
    changes in topic branches.
 
    ```bash
@@ -203,17 +203,17 @@ excellent pull request:
     with a clear title and description.
 
 8. If you haven't updated your pull request for a while, you should consider
-   rebasing on master and resolving any conflicts.
+   rebasing on main and resolving any conflicts.
 
-   **IMPORTANT**: _Never ever_ merge upstream `master` into your branches. You
-   should always `git rebase` on `master` to bring your changes up to date when
+   **IMPORTANT**: _Never ever_ merge upstream `main` into your branches. You
+   should always `git rebase` on `main` to bring your changes up to date when
    necessary.
 
    ```bash
-   git checkout master
-   git pull upstream master
+   git checkout main
+   git pull upstream main
    git checkout <your-topic-branch>
-   git rebase master
+   git rebase main
    ```
 
 Thank you for your contributions!
@@ -244,4 +244,4 @@ For formatting the guides:
 * We use backticks for module names, function names, and variable names.
 
 This contribution guide is adapted from the [Phoenix contribution
-guide](https://github.com/phoenixframework/phoenix/blob/master/CONTRIBUTING.md).
+guide](https://github.com/phoenixframework/phoenix/blob/main/CONTRIBUTING.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
-https://github.com/boydm/scenic/blob/master/.github/CONTRIBUTING.md
+https://github.com/ScenicFramework/scenic/blob/main/.github/CONTRIBUTING.md
 -->
 
 <!-- Provide a general summary of your changes in the Title above -->


### PR DESCRIPTION
## Description

Remove old outdated references to the previous master branch

A while back we switched the primary branch to main but we haven't yet removed all the references throughout the codebase

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
