### PR TITLE
Reduce Makefile prints to clean build output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,16 +53,12 @@ docs_report:
 	MIX_ENV=docs mix inch.report
 
 $(BUILD)/%.o: c_src/%.c
+	@echo " CC $(notdir $@)"
 	$(CC) -c $(ERL_CFLAGS) $(CFLAGS) -o $@ $<
 
-$(PREFIX)/line.so: $(BUILD)/line.o
-	$(CC) $^ $(ERL_LDFLAGS) $(LDFLAGS) -o $@
-
-$(PREFIX)/matrix.so: $(BUILD)/matrix.o
-	$(CC) $^ $(ERL_LDFLAGS) $(LDFLAGS) -o $@
-
-$(PREFIX)/bitmap.so: $(BUILD)/bitmap.o
-	$(CC) $^ $(ERL_LDFLAGS) $(LDFLAGS) -o $@
+$(PREFIX)/%.so: $(BUILD)/%.o
+	@echo " LD $(notdir $@)"
+	$(CC) $< $(ERL_LDFLAGS) $(LDFLAGS) -o $@
 
 $(PREFIX) $(BUILD):
 	mkdir -p $@
@@ -70,3 +66,5 @@ $(PREFIX) $(BUILD):
 clean:
 	$(RM) $(NIF) c_src/*.o
 
+# Don't echo commands unless the caller exports "V=1"
+${V}.SILENT:


### PR DESCRIPTION
Makefile and CC prints can be useful, but most of the time they are overwhelming especially for non-C programmers. This simplifies the prints.

To re-enable, set `V=1` like is common with many Makefile/C projects. For example `V=1 make`, `V=1 mix compile`, etc.

```
==> scenic
 CC line.o
 LD line.so
 CC matrix.o
 LD matrix.so
 CC bitmap.o
 LD bitmap.so
Compiling 84 files (.ex)
Generated scenic app
```