### PR TITLE
update install instructions for Ubuntu 24

### DIFF
--- a/guides/install_dependencies.md
+++ b/guides/install_dependencies.md
@@ -31,29 +31,17 @@ Some initial setup is required for windows. You'll need windows services for
 linux (WSL) and VcXsrv, [Jeffrey Borchert's article details these
 steps.](https://medium.com/@jeffborch/running-the-scenic-elixir-gui-framework-on-windows-10-using-wsl-f9c01fd276f6)
 
-## On Ubuntu 16
+## On Ubuntu 24
 
 The easiest way to install on Ubuntu is to use apt-get. Just run the following:
 
 ```bash
 sudo apt-get update
-sudo apt-get install pkgconf libglfw3 libglfw3-dev libglew1.13 libglew-dev
+sudo apt-get install pkgconf libgtk-3-0 libgtk-3-dev libsystemd-dev libwebp-dev libzstd-dev
 ```
 
 Once these components have been installed, you should be able to build the
-`scenic_driver_glfw` driver.
-
-## On Ubuntu 18
-
-The easiest way to install on Ubuntu is to use apt-get. Just run the following:
-
-```bash
-sudo apt-get update
-sudo apt-get install pkgconf libglfw3 libglfw3-dev libglew2.0 libglew-dev
-```
-
-Once these components have been installed, you should be able to build the
-`scenic_driver_glfw` driver.
+`scenic_driver_local` driver.
 
 ## On Fedora
 


### PR DESCRIPTION
## Description

Update the documentation for Ubuntu 24 dependency installation

## Motivation and Context

Recently I had to reinstall Scenic and tried to follow the old Ubuntu instructions, but a) they were outdated due to changed to `scenic_driver_local` and b) some of the packages in those instructions have been removed from apt, so they failed.

## Types of changes


- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [X] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

- [ ] Check other PRs and make sure that the changes are not done yet.
