### PR TITLE
Remove old documents

### DIFF
--- a/lib/scenic/scene.ex
+++ b/lib/scenic/scene.ex
@@ -1011,11 +1011,6 @@ defmodule Scenic.Scene do
   The callback supports all the return values of the
   [`init`](https://hexdocs.pm/elixir/GenServer.html#c:handle_cast/2)
   callback in [`Genserver`](https://hexdocs.pm/elixir/GenServer.html).
-
-  In addition to the normal return values defined by GenServer, a `Scene` can
-  add an optional `{push: graph}` term, which pushes the graph to the viewport.
-
-  This has replaced push_graph() as the preferred way to push a graph.
   """
   @callback handle_input(input :: Scenic.ViewPort.Input.t(), id :: any, scene :: Scene.t()) ::
               {:noreply, scene}
@@ -1052,11 +1047,6 @@ defmodule Scenic.Scene do
   The callback supports all the return values of the
   [`init`](https://hexdocs.pm/elixir/GenServer.html#c:handle_cast/2)
   callback in [`Genserver`](https://hexdocs.pm/elixir/GenServer.html).
-
-  In addition to the normal return values defined by GenServer, a `Scene` can
-  add an optional `{push: graph}` term, which pushes the graph to the viewport.
-
-  This has replaced push_graph() as the preferred way to push a graph.
   """
   @callback handle_event(event :: term, from :: pid, scene :: Scene.t()) ::
               {:noreply, scene}
@@ -1094,12 +1084,6 @@ defmodule Scenic.Scene do
   The callback supports all the return values of the
   [`init`](https://hexdocs.pm/elixir/GenServer.html#c:init/1)
   callback in [`Genserver`](https://hexdocs.pm/elixir/GenServer.html).
-
-  In addition to the normal return values defined by GenServer, a `Scene` can
-  return two new ones that push a graph to the viewport
-
-  Returning `{:ok, state, push: graph}` will push the indicated graph
-  to the ViewPort. This is preferable to the old push_graph() function.
   """
 
   @callback init(scene :: Scene.t(), args :: term(), options :: Keyword.t()) ::


### PR DESCRIPTION
Removes old `{:push, graph :: Graph.t()}` option from documentations.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/ScenicFramework/scenic/blob/main/.github/CONTRIBUTING.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit
message -->

## Description

<!--- Describe your changes in detail -->

`{:push, graph :: Graph.t()}` is removed from `Scenic.Scene.response_opts()` when it went to v0.11.
However the current document still insists that you can  return it from `Scenic.Scene.init()` callback.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

- [x] Check other PRs and make sure that the changes are not done yet.
